### PR TITLE
Make canvas an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "contributors": [
     "Jordan Santell <@jsantell>"
   ],
-  "dependencies": {
+  "optionalDependencies": {
     "canvas": "~1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This simple change makes `canvas` an optional dependency, so that imagediff can be insalled via npm for browser based projects (including using it with browserify). This will solve #22.
