### PR TITLE
Support module system for browser environment

### DIFF
--- a/js/imagediff.js
+++ b/js/imagediff.js
@@ -1,14 +1,10 @@
 (function (name, definition) {
   var root = this;
   if (typeof module !== 'undefined') {
+    var Canvas;
     try {
-      var Canvas = require('canvas');
-    } catch (e) {
-      throw new Error(
-        e.message + '\n' + 
-        'Please see https://github.com/HumbleSoftware/js-imagediff#cannot-find-module-canvas\n'
-      );
-    }
+      Canvas = require('canvas');
+    } catch (e) {}
     module.exports = definition(root, name, Canvas);
   } else if (typeof define === 'function' && typeof define.amd === 'object') {
     define(definition);
@@ -33,10 +29,17 @@
 
   // Creation
   function getCanvas (width, height) {
-    var
-      canvas = Canvas ?
-        new Canvas() :
-        document.createElement('canvas');
+    var canvas;
+    if (Canvas) {
+      canvas = new Canvas();
+    } else if (root.document && root.document.createElement) {
+      canvas = document.createElement('canvas');
+    } else {
+        throw new Error(
+          e.message + '\n' +
+          'Please see https://github.com/HumbleSoftware/js-imagediff#cannot-find-module-canvas\n'
+        );
+    }
     if (width) canvas.width = width;
     if (height) canvas.height = height;
     return canvas;


### PR DESCRIPTION
Currently a Node.js environment is recognised by checking for `require`-style imports. In that case the `canvas` dependency is required. The module fails if the dependency is not met.

This behaviour does not work when packaged using browserify. In this case the Node.js style `require`-style is present. However, we do not want to depend on there being a `canvas` module.

This commit changes the import handling of the optionally installed dependency by moving the code into the module itself. If a canvas dependency is provided it is used, if not the browser canvas element is. In case the latter is not available an error is thrown.

This change makes sure to provide the user with the possibility to alternatively override the default browser support. I do not know whether that is necessary, just feels like a good option to have for free.
