### PR TITLE
Deal with asynchrony when loading images in CLI

### DIFF
--- a/bin/imagediff
+++ b/bin/imagediff
@@ -9,6 +9,16 @@ function do_exit (is_equal) {
   process.exit(is_equal ? 0 : 1);
 }
 
+function loadImage (url, callback) {
+  var
+    image = new Canvas.Image();
+
+  image.onload = function () {
+    callback(image);
+  };
+  image.src = url;
+}
+
 function commandLine (args) {
 
   if (args.length < 3) {
@@ -19,10 +29,8 @@ function commandLine (args) {
   }
 
   var
-    a = new Canvas.Image(),
-    b = new Canvas.Image(),
     t = 0,
-    aName, bName, i, fn, equal, result, output;
+    aName, bName, i, fn, output;
 
   for (i = args.length - 2; i--;) {
     switch (args[i]) {
@@ -45,21 +53,27 @@ function commandLine (args) {
     if (args.length < 4) throw '-d option expects an output';
     output = args.pop();
   }
-  b.src = bName = args.pop();
-  a.src = aName = args.pop();
-  a = imagediff.toImageData(a);
-  b = imagediff.toImageData(b);
+  bName = args.pop();
+  aName = args.pop();
 
-  equal = imagediff.equal(a, b, t);
+  loadImage(bName, function (b) {
+    loadImage(aName, function (a) {
+      var
+        aData = imagediff.toImageData(a),
+        bData = imagediff.toImageData(b),
+        equal = imagediff.equal(aData, bData, t),
+        result;
 
-  if (fn === 'equal') {
-    process.stdout.write(equal ? 'true\n' : 'false\n');
-    do_exit(equal);
-  } else if (fn === 'diff') {
-    result = imagediff.diff(a, b, t);
-    imagediff.imageDataToPNG(result, output, function () {
-      do_exit(equal);
-      process.stdout.write('Diff of ' + aName + ' and ' + bName + ' rendered to ' + output + '\n');
+      if (fn === 'equal') {
+        process.stdout.write(equal ? 'true\n' : 'false\n');
+        do_exit(equal);
+      } else if (fn === 'diff') {
+        result = imagediff.diff(aData, bData, t);
+        imagediff.imageDataToPNG(result, output, function () {
+          do_exit(equal);
+          process.stdout.write('Diff of ' + aName + ' and ' + bName + ' rendered to ' + output + '\n');
+        });
+      }
     });
-  }
+  });
 };


### PR DESCRIPTION
This change hopefully fixes #17 by waiting for the images to be loaded before doing the diff.

There's some error cases the script doesn't catch, and a rather awkward CLI syntax (`diff` not `--diff`), but that's for another change to deal with.
