### PR TITLE
Fall back to browser's canvas for module import 'canvas' in browserify

### DIFF
--- a/browser/canvas.js
+++ b/browser/canvas.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function Canvas () {
+  return document.createElement('canvas');
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "imagediff",
   "main": "./imagediff.js",
+  "browser": {
+    "canvas": "./browser/canvas.js"
+  },
   "description": "JavaScript Canvas based imagediff utility.",
   "homepage": "http://HumbleSoftware.github.com/js-imagediff/",
   "keywords": [


### PR DESCRIPTION
This change implements option 2.ii. as discussed in #29 and would make imagediff browserifyable. Would then fix issue #29.
