### PR TITLE
Provide a global tolerance when comparing for equality

### DIFF
--- a/js/imagediff.js
+++ b/js/imagediff.js
@@ -148,7 +148,7 @@
   function equalDimensions (a, b) {
     return equalHeight(a, b) && equalWidth(a, b);
   }
-  function hasTotalDifference (aData, bData, absoluteTolerance) {
+  function hasTotalDifference (aData, bData, totalToleranceRatio) {
     var length         = aData.length,
         sumDifferences = 0,
         i;
@@ -156,12 +156,12 @@
       sumDifferences += Math.abs(aData[i] - bData[i]);
     };
 
-    return sumDifferences / (255 * length) <= (absoluteTolerance / 256);
+    return sumDifferences / (255 * length) <= totalToleranceRatio;
   }
-  function hasPerPixelDifference (aData, bData, absoluteTolerance) {
+  function hasPerPixelDifference (aData, bData, relativePixelTolerance) {
     var length = aData.length,
         i;
-    for (i = length; i--;) if (aData[i] !== bData[i] && Math.abs(aData[i] - bData[i]) > absoluteTolerance) return false;
+    for (i = length; i--;) if (aData[i] !== bData[i] && Math.abs(aData[i] - bData[i]) > relativePixelTolerance) return false;
     return true;
   }
   function equal (a, b, options) {
@@ -169,22 +169,24 @@
     var
       aData             = a.data,
       bData             = b.data,
-      absoluteTolerance = 0,
-      totalTolerance    = false;
+      toleranceValue, toleranceMethod;
 
+    // Support old interface
     if (typeof options === "number") {
-      // Support old interface
-      absoluteTolerance = options;
-    } else if (options) {
-      absoluteTolerance = (options.tolerance * 256) || 0;
-      totalTolerance = options.totalTolerance || false;
+      options = {
+        toleranceValue: options
+      };
     }
 
+    toleranceValue = options && options.toleranceValue || 0;
+    toleranceMethod = options && options.toleranceMethod || 'relativePerPixel';
+
     if (!equalDimensions(a, b)) return false;
-    if (totalTolerance) {
-      return hasTotalDifference(aData, bData, absoluteTolerance)
+
+    if (toleranceMethod === 'totalRatio') {
+      return hasTotalDifference(aData, bData, toleranceValue)
     } else {
-      return hasPerPixelDifference(aData, bData, absoluteTolerance);
+      return hasPerPixelDifference(aData, bData, toleranceValue);
     }
   }
 

--- a/spec/ImageDiffSpec.js
+++ b/spec/ImageDiffSpec.js
@@ -280,37 +280,44 @@ describe('ImageUtils', function() {
       it('should be equal within optional tolerance using new API', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 100;
-        expect(imagediff.equal(a, b, {tolerance: 101/256})).toEqual(true);
+        expect(imagediff.equal(a, b, {toleranceValue: 101, toleranceMethod: 'relativePerPixel'})).toEqual(true);
       });
 
       it('should be equal optional tolerance using new API', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 100;
-        expect(imagediff.equal(a, b, {tolerance: 100/256})).toEqual(true);
+        expect(imagediff.equal(a, b, {toleranceValue: 100, toleranceMethod: 'relativePerPixel'})).toEqual(true);
       });
 
       it('should not be equal outside tolerance using new API', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 100;
-        expect(imagediff.equal(a, b, {tolerance: 5/256})).toEqual(false);
+        expect(imagediff.equal(a, b, {toleranceValue: 5, toleranceMethod: 'relativePerPixel'})).toEqual(false);
       });
 
       it('should be equal within optional total tolerance', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 255;
-        expect(imagediff.equal(a, b, {tolerance: 1/4, totalTolerance: true})).toEqual(true);
+        expect(imagediff.equal(a, b, {toleranceValue: 1/4, toleranceMethod: 'totalRatio'})).toEqual(true);
       });
 
       it('should be equal optional total tolerance', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 255;
-        expect(imagediff.equal(a, b, {tolerance: 1/16, totalTolerance: true})).toEqual(true);
+        expect(imagediff.equal(a, b, {toleranceValue: 1/16, toleranceMethod: 'totalRatio'})).toEqual(true);
       });
 
       it('should not be equal outside total tolerance', function () {
         b = context.createImageData(2, 2);
         b.data[0] = 255;
-        expect(imagediff.equal(a, b, {tolerance: 1/20, totalTolerance: true})).toEqual(false);
+        expect(imagediff.equal(a, b, {toleranceValue: 1/20, toleranceMethod: 'totalRatio'})).toEqual(false);
+      });
+
+      it('should use tolerance method "relativePerPixel" by default', function () {
+        b = context.createImageData(2, 2);
+        b.data[0] = 100;
+        expect(imagediff.equal(a, b, {toleranceValue: 100})).toEqual(true);
+        expect(imagediff.equal(a, b, {toleranceValue: 99})).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
This PR tries to solve #18.

As proposed it implements an optional parameter set along the following example:

```
{
  tolerance : 0.05,
  totalTolerance : true
}
```

Following those changes `imagediff.equal(a, b, 128)` would be expressed through `imagediff.equal(a, b, {tolerance: 0.5})` in the future (however the old API remains intact).
A global tolerance can be given through adding `totalTolerance: true` to the option object.
