### PR TITLE
Included workaround for error 'Image given has not completed loading'...

### DIFF
--- a/imagediff.js
+++ b/imagediff.js
@@ -117,7 +117,9 @@
     canvas.width = width;
     canvas.height = height;
     context.clearRect(0, 0, width, height);
-    context.drawImage(image, 0, 0);
+    image.onload = function() {
+        context.drawImage(image, 0, 0);
+    }
     return context.getImageData(0, 0, width, height);
   }
   function toImageDataFromCanvas (canvas) {


### PR DESCRIPTION
... of canvas-library. The error was happening when working with lots of images to compare.

Found workaround here: Automattic/node-canvas#254

Comparing now works for me. Hope this helps anybody.
