### PR TITLE
fix loading ImageData from scaled Image elements

### DIFF
--- a/js/imagediff.js
+++ b/js/imagediff.js
@@ -114,7 +114,7 @@
     canvas.width = width;
     canvas.height = height;
     context.clearRect(0, 0, width, height);
-    context.drawImage(image, 0, 0);
+    context.drawImage(image, 0, 0, width, height);
     return context.getImageData(0, 0, width, height);
   }
   function toImageDataFromCanvas (canvas) {


### PR DESCRIPTION
Before, images would be drawn onto a canvas according to their document (possibly scaled) size, but with the image drawn based on their original (unscaled) size-- yielding accidental cropping. Fix this by explicitly drawing at their document size.
