### PR TITLE
update node-canvas dependency

### DIFF
--- a/imagediff.js
+++ b/imagediff.js
@@ -11,7 +11,7 @@
       var Canvas = require('canvas');
     } catch (e) {
       throw new Error(
-        e.message + '\n' + 
+        e.message + '\n' +
         'Please see https://github.com/HumbleSoftware/js-imagediff#cannot-find-module-canvas\n'
       );
     }
@@ -52,6 +52,10 @@
     canvas.height = height;
     context.clearRect(0, 0, width, height);
     return context.createImageData(width, height);
+  }
+  // expost canvas module
+  function getCanvasRef() {
+    return Canvas;
   }
 
 
@@ -352,6 +356,7 @@
 
     createCanvas : getCanvas,
     createImageData : getImageData,
+    getCanvasRef: getCanvasRef,
 
     isImage : isImage,
     isCanvas : isCanvas,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "Jordan Santell <@jsantell>"
   ],
   "optionalDependencies": {
-    "canvas": "~1.0"
+    "canvas": "~1.1.6"
   },
   "devDependencies": {
     "jasmine-node": ">=1.0.20",


### PR DESCRIPTION
This fixes an issue causing compilation failures on newer versions of Giflib
https://github.com/Automattic/node-canvas/pull/447

Can the version be bumped and pushed to npm too? Thanks!