### PR TITLE
fix link to demo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ To use matchers:
 Demo
 ----
 
-* A demo is available at http://humblesoftware.github.com/js-imagediff/
-* A Jasmine test demo is available at http://humblesoftware.github.com/js-imagediff/test.html
+* A demo is available at http://humblesoftware.github.io/js-imagediff/
+* A Jasmine test demo is available at http://humblesoftware.github.io/js-imagediff/test.html
 
 Users
 -----


### PR DESCRIPTION
https://github.blog/2013-04-05-new-github-pages-domain-github-io/

please also change the link in the "About"-section